### PR TITLE
feat: support single fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "es-module-lexer": "^1.5.4",
     "path-to-regexp": "^7.1.0",
     "puppeteer": "^23.1.0",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "turbo-stream": "^2.4.0"
   },
   "peerDependencies": {
     "@remix-run/dev": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   sharp:
     specifier: ^0.33.5
     version: 0.33.5
+  turbo-stream:
+    specifier: ^2.4.0
+    version: 2.4.0
 
 devDependencies:
   '@ossjs/release':
@@ -5851,6 +5854,10 @@ packages:
 
   /turbo-stream@2.3.0:
     resolution: {integrity: sha512-PhEr9mdexoVv+rJkQ3c8TjrN3DUghX37GNJkSMksoPR4KrXIPnM2MnqRt07sViIqX9IdlhrgtTSyjoVOASq6cg==}
+    dev: false
+
+  /turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
     dev: false
 
   /type-is@1.6.18:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export const OPEN_GRAPH_USER_AGENT_HEADER = 'vite-remix-og-image-plugin'
+export const OPEN_GRAPH_USER_AGENT_HEADER = 'remix-og-image'
 
 export interface OpenGraphImageData {
   name: string


### PR DESCRIPTION
- Closes #4 

## Changes

This adds support for Single fetch in Remix (still experimental feature flag). The plugin will be able to query the route correctly, using the new internal convention `.data?_route`. 

I'm not implementing the `_routes` support yet to keep the generate function deterministic. 