### PR TITLE
fix: improve performance by parallelizing build, browser, and preview

### DIFF
--- a/src/performance.ts
+++ b/src/performance.ts
@@ -1,0 +1,23 @@
+import {
+  performance as nativePerformance,
+  PerformanceObserver,
+} from 'node:perf_hooks'
+
+const { LOG_PERFORMANCE } = process.env
+
+if (LOG_PERFORMANCE) {
+  const observer = new PerformanceObserver((items) => {
+    items.getEntries().forEach((entry) => {
+      console.log(entry)
+    })
+  })
+
+  observer.observe({ entryTypes: ['measure'], buffered: true })
+}
+
+export const performance = LOG_PERFORMANCE
+  ? nativePerformance
+  : {
+      mark() {},
+      measure() {},
+    }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -36,8 +36,6 @@ const perfObserver = new PerformanceObserver((items) => {
 
 perfObserver.observe({ entryTypes: ['measure'], buffered: true })
 
-console.log('PERFORMANCE ACTIVATED!')
-
 interface Options {
   /**
    * Selector for the element to capture as the Open Graph image.
@@ -667,6 +665,11 @@ function createResourceRouteUrl(
 
   if (useSingleFetch) {
     url.pathname += '.data'
+    /**
+     * @note The `_routes` parameter is meant for fetching multiple loader
+     * data that match the route. It won't work if you have multiple different,
+     * independent routes, so we still need to fetch the loader data in multiple requests.
+     */
     url.searchParams.set('_route', route.id)
   } else {
     // Set the "_data" search parameter so the route can be queried
@@ -706,7 +709,7 @@ async function consumeLoaderResponse(
     throw new Error(`Failed to read loader response: response has no body`)
   }
 
-  // If the app is using Single fetch, decode the loader
+  // If the app is using Single Fetch, decode the loader
   // payload properly using the `turbo-stream` package.
   if (useSingleFetch) {
     const decodedBody = await decodeTurboStreamResponse(response)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -188,7 +188,18 @@ export function openGraphImagePlugin(options: Options): Plugin {
             `generate-image-${route.id}-${data.name}-pageload-start`
           )
 
-          await page.goto(pageUrl, { waitUntil: 'domcontentloaded' })
+          await Promise.all([
+            page.goto(pageUrl, { waitUntil: 'domcontentloaded' }),
+
+            // Set viewport to a 5K device equivalent.
+            // This is more than enough to ensure that the OG image is visible.
+            page.setViewport({
+              width: 5120,
+              height: 2880,
+              // Use a larger scale factor to get a crisp image.
+              deviceScaleFactor: 2,
+            }),
+          ])
 
           performance.mark(
             `generate-image-${route.id}-${data.name}-pageload-end`
@@ -198,15 +209,6 @@ export function openGraphImagePlugin(options: Options): Plugin {
             `generate-image-${route.id}-${data.name}-pageload-start`,
             `generate-image-${route.id}-${data.name}-pageload-end`
           )
-
-          // Set viewport to a 5K device equivalent.
-          // This is more than enough to ensure that the OG image is visible.
-          await page.setViewport({
-            width: 5120,
-            height: 2880,
-            // Use a larger scale factor to get a crisp image.
-            deviceScaleFactor: 2,
-          })
 
           const ogImageBoundingBox = await page
             .$(options.elementSelector)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -82,7 +82,7 @@ const CACHE_FILE = 'node_modules/.vite/cache/remix-og-image/cache.json'
 export function openGraphImagePlugin(options: Options): Plugin {
   if (path.isAbsolute(options.outputDirectory)) {
     throw new Error(
-      `Failed to initialize plugin: expected "outputDirectory" to be a relative path but got "${options.outputDirectory}". Please make sure it starts with "./".`
+      `Failed to initialize plugin: expected "outputDirectory" to be a relative path but got "${options.outputDirectory}". Please make sure it starts with "./".`,
     )
   }
 
@@ -93,7 +93,6 @@ export function openGraphImagePlugin(options: Options): Plugin {
   const vitePreviewPromise = new DeferredPromise<ViteDevServer>()
   const viteConfigPromise = new DeferredPromise<ResolvedConfig>()
   const remixContextPromise = new DeferredPromise<RemixPluginContext>()
-  const appUrlPromise = new DeferredPromise<URL>()
   const routesWithImages = new Set<ConfigRoute>()
 
   async function fromRemixApp(...paths: Array<string>): Promise<string> {
@@ -106,7 +105,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
     return path.resolve(
       remixContext.remixConfig.buildDirectory,
       'client',
-      ...paths
+      ...paths,
     )
   }
 
@@ -117,7 +116,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
   async function generateOpenGraphImages(
     route: ConfigRoute,
     browser: Browser,
-    appUrl: URL
+    appUrl: URL,
   ): Promise<Array<GeneratedOpenGraphImage>> {
     if (!route.path) {
       return []
@@ -169,7 +168,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
     performance.measure(
       `generate-image-${route.id}:loader`,
       `generate-image-${route.id}-loader-start`,
-      `generate-image-${route.id}-loader-end`
+      `generate-image-${route.id}-loader-end`,
     )
 
     const images: Array<GeneratedOpenGraphImage> = []
@@ -179,7 +178,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
         performance.mark(`generate-image-${route.id}-${data.name}-start`)
 
         performance.mark(
-          `generate-image-${route.id}-${data.name}-new-page-start`
+          `generate-image-${route.id}-${data.name}-new-page-start`,
         )
 
         const page = await browser.newPage()
@@ -188,14 +187,14 @@ export function openGraphImagePlugin(options: Options): Plugin {
         performance.measure(
           `generate-image-${route.id}-${data.name}:new-page`,
           `generate-image-${route.id}-${data.name}-new-page-start`,
-          `generate-image-${route.id}-${data.name}-new-page-end`
+          `generate-image-${route.id}-${data.name}-new-page-end`,
         )
 
         try {
           const pageUrl = new URL(createRoutePath(data.params), appUrl).href
 
           performance.mark(
-            `generate-image-${route.id}-${data.name}-pageload-start`
+            `generate-image-${route.id}-${data.name}-pageload-start`,
           )
 
           await Promise.all([
@@ -212,12 +211,12 @@ export function openGraphImagePlugin(options: Options): Plugin {
           ])
 
           performance.mark(
-            `generate-image-${route.id}-${data.name}-pageload-end`
+            `generate-image-${route.id}-${data.name}-pageload-end`,
           )
           performance.measure(
             `generate-image-${route.id}-${data.name}:pageload`,
             `generate-image-${route.id}-${data.name}-pageload-start`,
-            `generate-image-${route.id}-${data.name}-pageload-end`
+            `generate-image-${route.id}-${data.name}-pageload-end`,
           )
 
           const ogImageBoundingBox = await page
@@ -236,7 +235,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
           }
 
           performance.mark(
-            `generate-image-${route.id}-${data.name}-screenshot-start`
+            `generate-image-${route.id}-${data.name}-screenshot-start`,
           )
 
           const imageBuffer = await page.screenshot({
@@ -251,12 +250,12 @@ export function openGraphImagePlugin(options: Options): Plugin {
           })
 
           performance.mark(
-            `generate-image-${route.id}-${data.name}-screenshot-end`
+            `generate-image-${route.id}-${data.name}-screenshot-end`,
           )
           performance.measure(
             `generate-image-${route.id}-${data.name}:screenshot`,
             `generate-image-${route.id}-${data.name}-screenshot-start`,
-            `generate-image-${route.id}-${data.name}-screenshot-end`
+            `generate-image-${route.id}-${data.name}-screenshot-end`,
           )
 
           let imageStream = sharp(imageBuffer)
@@ -303,17 +302,17 @@ export function openGraphImagePlugin(options: Options): Plugin {
           performance.measure(
             `generate-image-${route.id}-${data.name}`,
             `generate-image-${route.id}-${data.name}-start`,
-            `generate-image-${route.id}-${data.name}-end`
+            `generate-image-${route.id}-${data.name}-end`,
           )
         }
-      })
+      }),
     )
 
     performance.mark(`generate-image-${route.id}-end`)
     performance.measure(
       `generate-image-${route.id}`,
       `generate-image-${route.id}-start`,
-      `generate-image-${route.id}-end`
+      `generate-image-${route.id}-end`,
     )
 
     cache.set(route.id, {
@@ -367,12 +366,12 @@ export function openGraphImagePlugin(options: Options): Plugin {
       }
 
       const routePath = normalizePath(
-        path.relative(remixContext.remixConfig.appDirectory, id)
+        path.relative(remixContext.remixConfig.appDirectory, id),
       )
       const route = Object.values(remixContext.remixConfig.routes).find(
         (route) => {
           return normalizePath(route.file) === routePath
-        }
+        },
       )
 
       // Ignore non-route modules.
@@ -419,7 +418,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
       if (routesWithImages.size === 0) {
         browserPromise.resolve(getBrowserInstance())
         vitePreviewPromise.resolve(
-          runVitePreviewServer(await viteConfigPromise)
+          runVitePreviewServer(await viteConfigPromise),
         )
       }
 
@@ -447,7 +446,7 @@ export function openGraphImagePlugin(options: Options): Plugin {
         ) {
           console.log(
             'Generating OG images for %d route(s)...',
-            routesWithImages.size
+            routesWithImages.size,
           )
 
           const [browser, server] = await Promise.all([
@@ -469,9 +468,9 @@ export function openGraphImagePlugin(options: Options): Plugin {
                 .then((images) => Promise.all(images.map(writeImage)))
                 .catch((error) => {
                   this.error(
-                    `Failed to generate OG image for route "${route.id}": ${error}`
+                    `Failed to generate OG image for route "${route.id}": ${error}`,
                   )
-                })
+                }),
             )
           }
 
@@ -501,14 +500,14 @@ async function getBrowserInstance(): Promise<Browser> {
   performance.measure(
     'browser-launch',
     'browser-launch-start',
-    'browser-launch-end'
+    'browser-launch-end',
   )
 
   return browser
 }
 
 async function runVitePreviewServer(
-  viteConfig: ResolvedConfig
+  viteConfig: ResolvedConfig,
 ): Promise<ViteDevServer> {
   /**
    * @note Force `NODE_ENV` to be "development" for the preview server.
@@ -534,14 +533,14 @@ async function runVitePreviewServer(
     // It will skip all the built-in development-oriented plugins in Vite.
     'production',
     'development',
-    false
+    false,
   )
 
   performance.mark('vite-preview-resolve-config-end')
   performance.measure(
     'vite-preview-resolve-config',
     'vite-preview-resolve-config-start',
-    'vite-preview-resolve-config-end'
+    'vite-preview-resolve-config-end',
   )
 
   performance.mark('vite-preview-server-start')
@@ -552,7 +551,7 @@ async function runVitePreviewServer(
   performance.measure(
     'vite-preview-server',
     'vite-preview-server-start',
-    'vite-preview-server-end'
+    'vite-preview-server-end',
   )
 
   return server.listen()
@@ -601,7 +600,7 @@ class Cache<K, V> extends Map<K, V> {
 async function getLoaderData(
   route: ConfigRoute,
   appUrl: URL,
-  useSingleFetch?: boolean
+  useSingleFetch?: boolean,
 ) {
   const url = createResourceRouteUrl(route, appUrl, useSingleFetch)
   const response = await fetch(url, {
@@ -610,30 +609,30 @@ async function getLoaderData(
     },
   }).catch((error) => {
     throw new Error(
-      `Failed to fetch Open Graph image data for route "${url.href}": ${error}`
+      `Failed to fetch Open Graph image data for route "${url.href}": ${error}`,
     )
   })
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with ${response.status}`
+      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with ${response.status}`,
     )
   }
 
   if (!response.body) {
     throw new Error(
-      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with no body. Did you forget to throw \`json(openGraphImage())\` in your loader?`
+      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with no body. Did you forget to throw \`json(openGraphImage())\` in your loader?`,
     )
   }
 
   const responseContentType = response.headers.get('content-type') || ''
   if (
     !responseContentType.includes(
-      useSingleFetch ? 'text/x-turbo' : 'application/json'
+      useSingleFetch ? 'text/x-turbo' : 'application/json',
     )
   ) {
     throw new Error(
-      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with invalid content type ("${responseContentType}"). Did you forget to throw \`json(openGraphImage())\` in your loader?`
+      `Failed to fetch Open Graph image data for route "${url.href}": loader responsed with invalid content type ("${responseContentType}"). Did you forget to throw \`json(openGraphImage())\` in your loader?`,
     )
   }
 
@@ -642,7 +641,7 @@ async function getLoaderData(
 
   if (!Array.isArray(data)) {
     throw new Error(
-      `Failed to fetch Open Graph image data for route "${url.href}": loader responded with invalid response. Did you forget to throw \`json(openGraphImage())\` in your loader?`
+      `Failed to fetch Open Graph image data for route "${url.href}": loader responded with invalid response. Did you forget to throw \`json(openGraphImage())\` in your loader?`,
     )
   }
 
@@ -656,11 +655,11 @@ async function getLoaderData(
 function createResourceRouteUrl(
   route: ConfigRoute,
   appUrl: URL,
-  useSingleFetch?: boolean
+  useSingleFetch?: boolean,
 ) {
   if (!route.path) {
     throw new Error(
-      `Failed to create resource route URL for route "${route.id}": route has no path`
+      `Failed to create resource route URL for route "${route.id}": route has no path`,
     )
   }
 
@@ -679,11 +678,11 @@ function createResourceRouteUrl(
 }
 
 async function decodeTurboStreamResponse(
-  response: Response
+  response: Response,
 ): Promise<Record<string, { data: unknown }>> {
   if (!response.body) {
     throw new Error(
-      `Failed to decode turbo-stream response: response has no body`
+      `Failed to decode turbo-stream response: response has no body`,
     )
   }
 
@@ -701,7 +700,7 @@ async function decodeTurboStreamResponse(
 async function consumeLoaderResponse(
   response: Response,
   route: ConfigRoute,
-  useSingleFetch?: boolean
+  useSingleFetch?: boolean,
 ): Promise<Array<OpenGraphImageData>> {
   if (!response.body) {
     throw new Error(`Failed to read loader response: response has no body`)
@@ -715,7 +714,7 @@ async function consumeLoaderResponse(
 
     if (!routePayload) {
       throw new Error(
-        `Failed to consume loader response for route "${route.id}": route not found in decoded response`
+        `Failed to consume loader response for route "${route.id}": route not found in decoded response`,
       )
     }
 
@@ -723,7 +722,7 @@ async function consumeLoaderResponse(
 
     if (!data) {
       throw new Error(
-        `Failed to consume loader response for route "${route.id}": route has no data`
+        `Failed to consume loader response for route "${route.id}": route has no data`,
       )
     }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { Writable } from 'node:stream'
-import { performance, PerformanceObserver } from 'node:perf_hooks'
 import {
   type Plugin,
   type ResolvedConfig,
@@ -22,19 +21,12 @@ import {
 } from 'babel-dead-code-elimination'
 import { compile } from 'path-to-regexp'
 import { Browser, launch } from 'puppeteer'
+import { performance } from './performance.js'
 import { parse, traverse, generate, t } from './babel.js'
 import {
   OPEN_GRAPH_USER_AGENT_HEADER,
   type OpenGraphImageData,
 } from './index.js'
-
-const perfObserver = new PerformanceObserver((items) => {
-  items.getEntries().forEach((entry) => {
-    console.log(entry)
-  })
-})
-
-perfObserver.observe({ entryTypes: ['measure'], buffered: true })
 
 interface Options {
   /**


### PR DESCRIPTION
These changes aim to improve the plugin's performance. 

## Changes

- Spawns Puppeteer as soon as the first OG image route is detected during the route modules transformation (vs waiting for the entire build to finish, _then_ spawning PT).
- Spawns Vite preview server as soon as the first OG image route is detected. 
- Drops `.toBuffer()` and preserves the `sharp.Sharp` stream, which is `Duplex`. Passes it directly to `fs.promises.writeFile()` so we don't read it twice (we don't really need to read it at all).
- Merges DOM element bounding box calculation and scrolling it to viewport into a single `page.evaluage()`.

## Profiling

```
loader: ~4s
pageload: ~1s
screenshot: ~4s
```

Maybe I'm measuring the screenshot time wrong but it is exponentially growing with each screenshot. This may indicate a memory leak. 

## Saved time

**~3s**.

## Possible time-saves

- [x] ~~If the app is using Single fetch in Remix, fetch all the OG image routes resources as a single `fetch` request. This should be a significant time-save.~~
  - My understanding on how `_routes` works in Remix was wrong. It's meant to fetch loader data for _matching_ loaders, not a list of arbitrary loaders. If you provide it a list of random loaders, Remix will ignore those that have nothing to do with the current route (the fetching is also route specific so you cannot fetch all on root).
- [x] ~~Skip closing pages?~~ The plugin will close the entire browser, which will close all the pages. This may negatively impact the RAM, slowing down the entire automation. 
- [x] ~~Consider [ignoring certain network requests](https://www.roborabbit.com/blog/mastering-puppeteer-tips-and-tricks-for-effortless-web-automation/#tip-4-disable-css-images-and-other-unneeded-resources-to-speed-up-puppeteer) to make the page load faster. This will only have effect if your nested layout is loading general data, like ads, that has no effect on the image.~~
  - This can be a nice customization option, but for now this results in no performance gain as I'm setting a simple image generation as a benchmark. 
- [x] ~~Consider chaining image writes to disk right in `generateRouteImages` vs adding it in `.then()`.~~
  - This yields no performance difference. 
