### PR TITLE
fix: cache at "node_modules/.cache"

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -65,7 +65,7 @@ interface CacheEntry {
 
 const PLUGIN_NAME = 'remix-og-image-plugin'
 const EXPORT_NAME = 'openGraphImage'
-const CACHE_FILE = 'node_modules/.vite/cache/remix-og-image/cache.json'
+const CACHE_FILE = 'node_modules/.cache/remix-og-image/cache.json'
 
 export function openGraphImagePlugin(options: Options): Plugin {
   if (path.isAbsolute(options.outputDirectory)) {


### PR DESCRIPTION
Changes the cache folder to be `node_modules/.cache` so it has better support of build cache on various deployment platforms. 

- Related to #19 