### PR TITLE
fix: make `params` optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export const OPEN_GRAPH_USER_AGENT_HEADER = 'remix-og-image'
 
 export interface OpenGraphImageData {
   name: string
-  params: Record<string, string>
+  params?: Record<string, string>
 }
 
 export function isOpenGraphImageRequest(request: Request): boolean {


### PR DESCRIPTION
- Fixes #28 

The `params` property is optional and only relevant for dynamic routes. 